### PR TITLE
Add tokens to keep ratio option

### DIFF
--- a/DEPLOYMENT_SETUP.md
+++ b/DEPLOYMENT_SETUP.md
@@ -104,6 +104,10 @@ Go to your GitHub repository → Settings → Secrets and variables → Actions 
   - Example: "2.0" removes ~50% of tokens, "3.0" removes ~67% of tokens
   - **Note**: This is set as a repository variable (not a secret) since it's not sensitive information
 
+- **`TOKENS_TO_KEEP_RATIO`**: Alternative to `COMPRESSION_RATIO`. If set to a value < 1.0, it keeps this fraction of tokens (e.g., `0.7` keeps ~70%) and overrides `COMPRESSION_RATIO`.
+  - Default: unset
+  - Example: `0.6` keeps ~60% of tokens
+
 ### 2. Customize Deployment Settings
 
 You can modify the deployment settings in `.github/workflows/deploy.yml`:
@@ -126,6 +130,9 @@ gcloud builds submit --config cloudbuild.yaml
 
 # Deploy with custom compression ratio
 gcloud builds submit --config cloudbuild.yaml --substitutions _COMPRESSION_RATIO=2.0
+
+# Or deploy using tokens-to-keep (overrides compression ratio)
+gcloud builds submit --config cloudbuild.yaml --substitutions _TOKENS_TO_KEEP_RATIO=0.7
 ```
 
 The Cloud Build configuration uses substitution variables, so you can override the compression ratio at build time without modifying the file.
@@ -141,6 +148,8 @@ docker build -t openai-proxy .
 
 # Run locally
 docker run -p 8080:8080 -e COMPRESSION_RATIO=1.0 openai-proxy
+# Or
+docker run -p 8080:8080 -e TOKENS_TO_KEEP_RATIO=0.7 openai-proxy
 
 # Test health endpoint
 curl http://localhost:8080/health

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -36,10 +36,11 @@ steps:
       - '--port'
       - '8080'
       - '--set-env-vars'
-      - 'COMPRESSION_RATIO=${_COMPRESSION_RATIO}'
+      - 'COMPRESSION_RATIO=${_COMPRESSION_RATIO},TOKENS_TO_KEEP_RATIO=${_TOKENS_TO_KEEP_RATIO}'
 
 images:
   - 'gcr.io/$PROJECT_ID/openai-proxy:$COMMIT_SHA'
 
 substitutions:
-  _COMPRESSION_RATIO: '1.0' 
+  _COMPRESSION_RATIO: '1.0'
+  _TOKENS_TO_KEEP_RATIO: '1.0' 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Manual deployment script for Google Cloud Run
-# Usage: ./deploy.sh [PROJECT_ID] [REGION] [COMPRESSION_RATIO]
+# Usage: ./deploy.sh [PROJECT_ID] [REGION] [COMPRESSION_RATIO] [TOKENS_TO_KEEP_RATIO]
 
 set -e
 
@@ -11,12 +11,14 @@ REGION=${2:-us-central1}
 SERVICE_NAME="openai-proxy"
 IMAGE_NAME="gcr.io/$PROJECT_ID/$SERVICE_NAME"
 COMPRESSION_RATIO=${3:-1.0}
+TOKENS_TO_KEEP_RATIO=${4:-1.0}
 
 echo "🚀 Deploying OpenAI Proxy to Google Cloud Run"
 echo "Project: $PROJECT_ID"
 echo "Region: $REGION"
 echo "Service: $SERVICE_NAME"
 echo "Compression Ratio: $COMPRESSION_RATIO"
+echo "Tokens To Keep Ratio: $TOKENS_TO_KEEP_RATIO"
 echo ""
 
 # Check if gcloud is installed and authenticated
@@ -69,7 +71,7 @@ gcloud run deploy $SERVICE_NAME \
     --max-instances=10 \
     --min-instances=0 \
     --concurrency=100 \
-    --set-env-vars="COMPRESSION_RATIO=$COMPRESSION_RATIO" \
+    --set-env-vars="COMPRESSION_RATIO=$COMPRESSION_RATIO,TOKENS_TO_KEEP_RATIO=$TOKENS_TO_KEEP_RATIO" \
     --port=8080
 
 # Get service URL

--- a/main.py
+++ b/main.py
@@ -29,13 +29,20 @@ OPENAI_BASE_URL = "https://api.openai.com/v1"
 
 # Compression configuration
 COMPRESSION_RATIO = float(os.getenv("COMPRESSION_RATIO", "1.0"))  # Default no compression
+_TOKENS_TO_KEEP_RATIO_ENV = os.getenv("TOKENS_TO_KEEP_RATIO", None)
+TOKENS_TO_KEEP_RATIO = None if _TOKENS_TO_KEEP_RATIO_ENV in (None, "") else float(_TOKENS_TO_KEEP_RATIO_ENV)
 
-def compress_text(text: str, compression_ratio: float) -> str:
+def compress_text(text: str, compression_ratio: float, tokens_to_keep_ratio: Optional[float] = None) -> str:
     """
     Simple token-based compression algorithm.
-    Removes N random tokens where N = token_count * (1 - 1/compression_ratio)
+    Removes N random tokens where:
+      - If tokens_to_keep_ratio is provided and < 1.0: N = token_count * (1 - tokens_to_keep_ratio)
+      - Else if compression_ratio > 1.0: N = token_count * (1 - 1/compression_ratio)
     """
-    if compression_ratio <= 1.0:
+    if tokens_to_keep_ratio is not None:
+        if tokens_to_keep_ratio >= 1.0:
+            return text
+    elif compression_ratio <= 1.0:
         return text  # No compression needed
     
     try:
@@ -50,7 +57,10 @@ def compress_text(text: str, compression_ratio: float) -> str:
             return text
         
         # Calculate how many tokens to remove
-        tokens_to_remove = int(token_count * (1 - 1/compression_ratio))
+        if tokens_to_keep_ratio is not None and tokens_to_keep_ratio < 1.0:
+            tokens_to_remove = int(token_count * (1 - tokens_to_keep_ratio))
+        else:
+            tokens_to_remove = int(token_count * (1 - 1/compression_ratio))
         
         if tokens_to_remove <= 0:
             return text
@@ -73,7 +83,7 @@ def compress_text(text: str, compression_ratio: float) -> str:
         
         # Log compression details
         compression_logger.info("=" * 80)
-        compression_logger.info(f"COMPRESSION APPLIED - Ratio: {compression_ratio}")
+        compression_logger.info(f"COMPRESSION APPLIED - Ratio: {compression_ratio}, TokensToKeepRatio: {tokens_to_keep_ratio}")
         compression_logger.info(f"Original tokens: {token_count}")
         compression_logger.info(f"Compressed tokens: {len(compressed_tokens)}")
         compression_logger.info(f"Removed tokens: {tokens_to_remove}")
@@ -91,11 +101,14 @@ def compress_text(text: str, compression_ratio: float) -> str:
         logger.warning(f"Compression failed: {e}, returning original text")
         return text
 
-def compress_chat_messages(messages: list, compression_ratio: float) -> list:
+def compress_chat_messages(messages: list, compression_ratio: float, tokens_to_keep_ratio: Optional[float] = None) -> list:
     """
     Apply compression to chat messages, focusing on user messages
     """
-    if compression_ratio <= 1.0:
+    if tokens_to_keep_ratio is not None:
+        if tokens_to_keep_ratio >= 1.0:
+            return messages
+    elif compression_ratio <= 1.0:
         return messages
     
     compressed_messages = []
@@ -107,7 +120,7 @@ def compress_chat_messages(messages: list, compression_ratio: float) -> list:
             if isinstance(content, str):
                 user_message_count += 1
                 compression_logger.info(f"COMPRESSING USER MESSAGE #{user_message_count} (position {i})")
-                compressed_content = compress_text(content, compression_ratio)
+                compressed_content = compress_text(content, compression_ratio, tokens_to_keep_ratio)
                 compressed_message = message.copy()
                 compressed_message["content"] = compressed_content
                 compressed_messages.append(compressed_message)
@@ -143,7 +156,12 @@ def main(request):
             body = request.get_data()
             
             # Apply compression for chat completions
-            if body and path.endswith("chat/completions") and COMPRESSION_RATIO > 1.0:
+            should_compress = False
+            if TOKENS_TO_KEEP_RATIO is not None:
+                should_compress = TOKENS_TO_KEEP_RATIO < 1.0
+            else:
+                should_compress = COMPRESSION_RATIO > 1.0
+            if body and path.endswith("chat/completions") and should_compress:
                 try:
                     body_str = body.decode('utf-8')
                     body_data = json.loads(body_str)
@@ -151,12 +169,16 @@ def main(request):
                         compression_logger.info(f"NEW CHAT COMPLETION REQUEST - Timestamp: {datetime.now().isoformat()}")
                         compression_logger.info(f"Target URL: {target_url}")
                         compression_logger.info(f"Compression ratio: {COMPRESSION_RATIO}")
+                        compression_logger.info(f"Tokens to keep ratio: {TOKENS_TO_KEEP_RATIO}")
                         compression_logger.info("")
                         
-                        body_data["messages"] = compress_chat_messages(body_data["messages"], COMPRESSION_RATIO)
+                        body_data["messages"] = compress_chat_messages(body_data["messages"], COMPRESSION_RATIO, TOKENS_TO_KEEP_RATIO)
                         new_body_str = json.dumps(body_data, ensure_ascii=False)
                         body = new_body_str.encode('utf-8')
-                        logger.info(f"Applied compression ratio {COMPRESSION_RATIO} to chat completion request")
+                        if TOKENS_TO_KEEP_RATIO is not None:
+                            logger.info(f"Applied tokens_to_keep_ratio {TOKENS_TO_KEEP_RATIO} to chat completion request")
+                        else:
+                            logger.info(f"Applied compression ratio {COMPRESSION_RATIO} to chat completion request")
                 except json.JSONDecodeError as e:
                     logger.warning(f"Failed to parse JSON for compression: {e}")
                 except UnicodeDecodeError as e:
@@ -248,7 +270,9 @@ if __name__ == "__main__":
     
     logger.info(f"Starting OpenAI proxy server on {host}:{port}")
     logger.info(f"Forwarding requests to {OPENAI_BASE_URL}")
-    if COMPRESSION_RATIO > 1.0:
+    if TOKENS_TO_KEEP_RATIO is not None and TOKENS_TO_KEEP_RATIO < 1.0:
+        logger.info(f"Compression enabled with tokens_to_keep_ratio {TOKENS_TO_KEEP_RATIO} (removes ~{100*(1-TOKENS_TO_KEEP_RATIO):.1f}% of tokens)")
+    elif COMPRESSION_RATIO > 1.0:
         logger.info(f"Compression enabled with ratio {COMPRESSION_RATIO} (removes ~{100*(1-1/COMPRESSION_RATIO):.1f}% of tokens)")
     else:
         logger.info("Compression disabled")


### PR DESCRIPTION
Add `tokens_to_keep_ratio` as an alternative compression parameter to provide a more intuitive way to control token reduction.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c3ca924-53f0-4736-a62a-3d91880b1973">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2c3ca924-53f0-4736-a62a-3d91880b1973">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

